### PR TITLE
Log the file which was used to determine the perl version

### DIFF
--- a/lib/Dist/Zilla/Plugin/MinimumPerl.pm
+++ b/lib/Dist/Zilla/Plugin/MinimumPerl.pm
@@ -74,6 +74,7 @@ sub register_prereqs {
 			}
 			if ( ! defined $minver or $ver > $minver ) {
 				$minver = $ver;
+				$self->log_debug("Via ".$file->name.", set perl version to ".$ver->stringify);
 			}
 		}
 


### PR DESCRIPTION
This makes it easier to track why a specific version was chosen.
