### PR TITLE
See also: MinimumPerlFast

### DIFF
--- a/lib/Dist/Zilla/Plugin/MinimumPerl.pm
+++ b/lib/Dist/Zilla/Plugin/MinimumPerl.pm
@@ -117,5 +117,6 @@ If you need it to scan a different directory and/or a different extension please
 
 =head1 SEE ALSO
 Dist::Zilla
+Dist::Zilla::Plugin::MinimumPerlFast
 
 =cut


### PR DESCRIPTION
[MinimumPerlFast](https://metacpan.org/module/Dist::Zilla::Plugin::MinimumPerlFast) is an interesting alternative for perl 5.8+
