### PR TITLE
Fix use of file finders

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for Dist::Zilla::Plugin::MinimumPerl
 
 {{$NEXT}}
  - extend the scanning of runtime prerequisites to include executables
+ - file finder options are now documented
 
 1.005 2014-10-31T17:29:36Z UTC
  - Reverted the removal of the filename check while scanning files -

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Dist::Zilla::Plugin::MinimumPerl
 
 {{$NEXT}}
+ - extend the scanning of runtime prerequisites to include executables
 
 1.005 2014-10-31T17:29:36Z UTC
  - Reverted the removal of the filename check while scanning files -

--- a/Changes
+++ b/Changes
@@ -3,6 +3,8 @@ Revision history for Dist::Zilla::Plugin::MinimumPerl
 {{$NEXT}}
  - extend the scanning of runtime prerequisites to include executables
  - file finder options are now documented
+ - reverted the reversion of the filename check: a custom filefinder can do
+   this for you if necessary
 
 1.005 2014-10-31T17:29:36Z UTC
  - Reverted the removal of the filename check while scanning files -

--- a/lib/Dist/Zilla/Plugin/MinimumPerl.pm
+++ b/lib/Dist/Zilla/Plugin/MinimumPerl.pm
@@ -148,8 +148,34 @@ for your dist and adds it to the prereqs.
 	# In your dist.ini:
 	[MinimumPerl]
 
-This plugin will search for files matching C</\.(t|pl|pm)$/i> in the C<lib/>, C<inc/>, and C<t/> directories.
-If you need it to scan a different directory and/or a different extension please let me know.
+=head1 CONFIGURATION OPTIONS
+
+The plugin uses L<FileFinders|Dist::Zilla::Role::FileFinder> for finding files
+to scan.  The predefined finders are listed in
+L<Dist::Zilla::Role::FileFinderUser/default_finders>.
+You can define your own with the
+L<[FileFinder::ByName]|Dist::Zilla::Plugin::FileFinder::ByName> and
+L<[FileFinder::Filter]|Dist::Zilla::Plugin::FileFinder::Filter> plugins.
+
+Additionally, all files whose encoding has been specified as C<bytes> are
+omitted from consideration.  (See L<[Encoding]|Dist::Zilla::Plugin::Encoding>
+for more information.)
+
+Each prerequisite phase is configured separately:
+
+=head2 C<runtime_finder>
+
+Finds files to scan for runtime prerequisites.  The default value is
+C<:InstallModules> and C<:ExecFiles> (see also
+L<Dist::Zilla::Plugin::ExecDir>.
+
+=head2 C<test_finder>
+
+Finds files to scan for test prerequisites. The default value is C<:TestFiles>.
+
+=head2 C<configure_finder>
+
+Finds files to scan for configure prerequisites. The default value is C<:IncModules>.
 
 =head1 SEE ALSO
 Dist::Zilla

--- a/lib/Dist/Zilla/Plugin/MinimumPerl.pm
+++ b/lib/Dist/Zilla/Plugin/MinimumPerl.pm
@@ -9,7 +9,6 @@ use MooseX::Types::Perl 0.101340 qw( LaxVersionStr );
 with(
 	'Dist::Zilla::Role::PrereqSource' => { -version => '5.006' }, # for the updated encoding system in dzil, RJBS++
 	'Dist::Zilla::Role::FileFinderUser' => {
-		-version => '4.200006',	# for :IncModules
 		finder_arg_names => [ 'perl_Modules' ],
 		method => 'found_modules',
 		default_finders => [ ':InstallModules' ]
@@ -20,6 +19,7 @@ with(
 		default_finders => [ ':TestFiles' ]
 	},
 	'Dist::Zilla::Role::FileFinderUser' => {
+		-version => '4.200006',	# for :IncModules
 		finder_arg_names => [ 'perl_Inc' ],
 		method => 'found_inc',
 		default_finders => [ ':IncModules' ]

--- a/lib/Dist/Zilla/Plugin/MinimumPerl.pm
+++ b/lib/Dist/Zilla/Plugin/MinimumPerl.pm
@@ -9,19 +9,19 @@ use MooseX::Types::Perl 0.101340 qw( LaxVersionStr );
 with(
 	'Dist::Zilla::Role::PrereqSource' => { -version => '5.006' }, # for the updated encoding system in dzil, RJBS++
 	'Dist::Zilla::Role::FileFinderUser' => {
-		finder_arg_names => [ 'perl_Modules' ],
-		method => 'found_modules',
+		finder_arg_names => [ 'runtime_finder' ],
+		method => 'found_runtime',
 		default_finders => [ ':InstallModules', ':ExecFiles' ]
 	},
 	'Dist::Zilla::Role::FileFinderUser' => {
-		finder_arg_names => [ 'perl_Tests' ],
+		finder_arg_names => [ 'test_finder' ],
 		method => 'found_tests',
 		default_finders => [ ':TestFiles' ]
 	},
 	'Dist::Zilla::Role::FileFinderUser' => {
 		-version => '4.200006',	# for :IncModules
-		finder_arg_names => [ 'perl_Inc' ],
-		method => 'found_inc',
+		finder_arg_names => [ 'configure_finder' ],
+		method => 'found_configure',
 		default_finders => [ ':IncModules' ]
 	},
 );
@@ -73,9 +73,9 @@ sub register_prereqs {
 		}
 	} else {
 		# Go through our 3 phases
-		$self->_scan_file( 'runtime', $_ ) for @{ $self->found_modules };
+		$self->_scan_file( 'runtime', $_ ) for @{ $self->found_runtime };
 		$self->_finalize( 'runtime' );
-		$self->_scan_file( 'configure', $_ ) for @{ $self->found_inc };
+		$self->_scan_file( 'configure', $_ ) for @{ $self->found_configure };
 		$self->_finalize( 'configure' );
 		$self->_scan_file( 'test', $_ ) for @{ $self->found_tests };
 		$self->_finalize( 'test' );

--- a/lib/Dist/Zilla/Plugin/MinimumPerl.pm
+++ b/lib/Dist/Zilla/Plugin/MinimumPerl.pm
@@ -87,8 +87,6 @@ sub _scan_file {
 
 	# We don't parse files marked with the 'bytes' encoding as they're special - see RT#96071
 	return if $file->is_bytes;
-	# Only check .t and .pm/pl files, thanks RT#67355 and DOHERTY
-	return unless $file->name =~ /\.(?:t|p[ml])$/i;
 
 	# TODO skip "bad" files and not die, just warn?
 	my $pmv = Perl::MinimumVersion->new( \$file->content );

--- a/lib/Dist/Zilla/Plugin/MinimumPerl.pm
+++ b/lib/Dist/Zilla/Plugin/MinimumPerl.pm
@@ -11,7 +11,7 @@ with(
 	'Dist::Zilla::Role::FileFinderUser' => {
 		finder_arg_names => [ 'perl_Modules' ],
 		method => 'found_modules',
-		default_finders => [ ':InstallModules' ]
+		default_finders => [ ':InstallModules', ':ExecFiles' ]
 	},
 	'Dist::Zilla::Role::FileFinderUser' => {
 		finder_arg_names => [ 'perl_Tests' ],


### PR DESCRIPTION
- extend the scanning of runtime prerequisites to include executables
- document the file finder options
- renamed the file finder options to indicate what they mean, not their present defaults
- reverted the reversion of the filename check - with this in place, it is IMPOSSIBLE to scan executables that don't have a .pm/.pl suffix - e.g. https://metacpan.org/pod/distribution/App-Uni/bin/uni
