### PR TITLE
RT#105402 use dzil's PPI cache

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -1,2 +1,3 @@
 name = Dist-Zilla-Plugin-MinimumPerl
+[Bootstrap::lib]
 [@Apocalyptic]

--- a/lib/Dist/Zilla/Plugin/MinimumPerl.pm
+++ b/lib/Dist/Zilla/Plugin/MinimumPerl.pm
@@ -8,6 +8,7 @@ use MooseX::Types::Perl 0.101340 qw( LaxVersionStr );
 
 with(
 	'Dist::Zilla::Role::PrereqSource' => { -version => '5.006' }, # for the updated encoding system in dzil, RJBS++
+	'Dist::Zilla::Role::PPI',
 	'Dist::Zilla::Role::FileFinderUser' => {
 		finder_arg_names => [ 'runtime_finder' ],
 		method => 'found_runtime',
@@ -89,7 +90,7 @@ sub _scan_file {
 	return if $file->is_bytes;
 
 	# TODO skip "bad" files and not die, just warn?
-	my $pmv = Perl::MinimumVersion->new( \$file->content );
+	my $pmv = Perl::MinimumVersion->new( $self->ppi_document_for_file($file) );
 	if ( ! defined $pmv ) {
 		$self->log_fatal( "Unable to parse '" . $file->name . "'" );
 	}


### PR DESCRIPTION
Candidate fix for [RT#105402](https://rt.cpan.org/Ticket/Display.html?id=105402): use Dist::Zilla::PPI::Role to cache PPI documents.

I've not been able to test if those changes work because the `[@Apocalyptic]` plugin bundle is [a nightmare to use](https://rt.cpan.org/Ticket/Display.html?id=104091) for contributors.
